### PR TITLE
ios fullscreen presentation

### DIFF
--- a/ios/Classes/Bridge/StartStudioBridge.swift
+++ b/ios/Classes/Bridge/StartStudioBridge.swift
@@ -37,7 +37,13 @@ struct StartStudioBridge: BaseBridge {
                 }
             })
 
-            getFlutterViewController()?.present(try onfidoFlow.run(), animated: true)
+            let vc = getFlutterViewController()
+            var modalPresentationStyle: UIModalPresentationStyle = .fullScreen
+            guard vc != nil else {
+                result(FlutterError(code: "exit", message: "getFlutterViewController returned nil", details: nil))
+                return
+            }
+            try onfidoFlow.run(from: vc!, presentationStyle: modalPresentationStyle)
         } catch {
             result(FlutterError(code: "configuration", message: error.localizedDescription, details: "\(error)"))
         }


### PR DESCRIPTION
According to the readme of [onfido-ios-sdk](https://github.com/onfido/onfido-ios-sdk) the Onfido flow is supposed to be shown in fullscreen on iPhones, but with the current implementation, it is presented as a modal.
This PR changes the presentation style to be fullscreen.

Current presentation style:
![Simulator Screenshot - iPhone 14 Pro Max - 2023-10-13 at 12 31 34](https://github.com/onfido/flutter-sdk/assets/7204248/7e87be41-27f4-44d1-b674-7d9b9b1cd88c)
