### PR TITLE
Allow any uiviewcontroller

### DIFF
--- a/ios/Classes/Helpers/FlutterViewController.swift
+++ b/ios/Classes/Helpers/FlutterViewController.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-func getFlutterViewController() -> FlutterViewController? {
+func getFlutterViewController() -> UIViewController? {
     var window: UIWindow?
     if #available(iOS 13.0, *) {
         window = UIApplication
@@ -19,5 +19,5 @@ func getFlutterViewController() -> FlutterViewController? {
     } else {
         window = UIApplication.shared.windows.first { $0.isKeyWindow }
     }
-    return window?.rootViewController as? FlutterViewController
+    return window?.rootViewController as? UIViewController
 }


### PR DESCRIPTION
When using the flutter engine directly, the root view controller could be something else than an FlutterViewController. This fix allow to start the Onfido sdk in that case.

https://docs.flutter.dev/add-to-app